### PR TITLE
Send Selected Text as Prompt with Instructions via Modal (#14)

### DIFF
--- a/src/apiService.ts
+++ b/src/apiService.ts
@@ -1,0 +1,390 @@
+import { App, Editor } from "obsidian";
+import { ERROR_MESSAGES } from "@/constants";
+import {
+	IPluginServices,
+	GptEngines,
+	GptRequestPayload,
+	GptChatResponse,
+} from "@/interfaces";
+import { GptPluginSettings } from "@/settings";
+import { GptView } from "@/view";
+
+export default class ApiService {
+	app: App;
+	pluginServices: IPluginServices;
+	settings: GptPluginSettings;
+
+	constructor(
+		app: App,
+		pluginServices: IPluginServices,
+		settings: GptPluginSettings
+	) {
+		this.app = app;
+		this.pluginServices = pluginServices;
+		this.settings = settings;
+	}
+
+	async sendPromptWithSelectedText(
+		promptWithSelectedText: string
+	): Promise<void> {
+
+		const leaf = await this.pluginServices.activateView();
+		if (!leaf) {
+			console.error(ERROR_MESSAGES.viewError);
+			this.pluginServices.notifyError("viewError");
+			return;
+		}
+		const container = leaf.view.containerEl.children[1].createEl("div", { cls: "gpt-msg-container" });
+		
+		const gptModel = this.settings.openaiModel;
+		const apiKey = this.settings.openaiApiKey;
+		const apiUrl = this.settings.openaiChatUrl;
+
+		const payload: GptRequestPayload = {
+			model: gptModel,
+			messages: [
+				{
+					role: "user",
+					content: promptWithSelectedText,
+				},
+			],
+			stream: true,
+			temperature: 0.7,
+		};
+
+		const requestOptions = {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${apiKey}`,
+			},
+			body: JSON.stringify(payload),
+		};
+
+		try {
+			const response = await fetch(apiUrl, requestOptions);
+			if (!response.body) {
+				return;
+			}
+
+			const reader = response.body.getReader();
+			const decoder = new TextDecoder();
+			let isReading = true;
+			let paragraphText = "";
+
+			if (leaf.view instanceof GptView) {
+				let x = 0;
+				while (isReading) {
+					if (x > 500) {
+						isReading = false;
+						console.error("BOOM! Reached limit.");
+						break;
+					}
+					x++;
+
+					const { done, value } = await reader.read();
+					if (done) {
+						isReading = false;
+						break;
+					}
+					const chunkText = decoder.decode(value, { stream: true });
+					// Some of this is based on the example from @schnerd's comment here:
+					// https://github.com/openai/openai-node/issues/18#issuecomment-1369996933
+					const jsonLines = chunkText
+						.split("\n")
+						.filter((line) => line.trim() !== "");
+					for (const jsonLine of jsonLines) {
+						const message = jsonLine.replace(/^data: /, "");
+						if (message === "[DONE]") {
+							break;
+						}
+						try {
+							const parsed = JSON.parse(message);
+							if (parsed.choices[0]?.delta?.content) {
+								const word: string = parsed.choices[0].delta.content.toString();
+								leaf.view.renderSelectedTextResponse(word, container);
+								paragraphText += word;
+							}
+						} catch (error) {
+							console.error(
+								"Could not JSON parse stream message",
+								message,
+								error
+							);
+						}
+					}
+				}
+				console.log(paragraphText);
+			}
+		} catch (error) {
+			console.error("Fetch error:", error);
+		}
+	}
+
+	// `engines` endpoint
+	public async getEngines(): Promise<string[]> {
+		if (!this.hasApiKey()) {
+			this.pluginServices.notifyError("noApiKey");
+			return [ERROR_MESSAGES.noApiKey];
+		}
+
+		const leaf = await this.pluginServices.activateView();
+		if (!leaf) {
+			console.error(ERROR_MESSAGES.viewError);
+			return [ERROR_MESSAGES.viewError];
+		}
+
+		const apiKey = this.settings.openaiApiKey;
+		const apiUrl = this.settings.openaiEnginesUrl;
+
+		try {
+			// No need to import fetch; it's globally available in Node.js 17.5+.
+			const response = await fetch(apiUrl, {
+				method: "GET",
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+				},
+			});
+
+			// Assuming the API returns JSON
+			const data = await response.json();
+			const engines: string[] = data.data
+				.map((engine: GptEngines) => engine.id)
+				.sort();
+			console.table(engines);
+			if (leaf.view instanceof GptView) {
+				leaf.view.updateEngines(engines);
+			}
+			return engines;
+		} catch (error) {
+			this.pluginServices.notifyError("noEngines");
+			console.error("Error:", error);
+			return [ERROR_MESSAGES.noEngines];
+		}
+	}
+
+	// Generic function to get a response from the GPT chat API based on a payload
+	async getGptChatResponse(
+		payload: GptRequestPayload
+	): Promise<GptChatResponse> {
+		const apiKey = this.settings.openaiApiKey;
+		const apiUrl = this.settings.openaiChatUrl;
+
+		try {
+			const response = await fetch(apiUrl, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${apiKey}`,
+				},
+				body: JSON.stringify(payload),
+			});
+
+			if (!response.ok) {
+				return {
+					success: false,
+					message: "",
+					error: `HTTP error status: ${response.status}`,
+				};
+			}
+
+			const data = await response.json();
+
+			return { success: true, message: data.choices[0].message.content };
+		} catch (error) {
+			console.error("Error:", error);
+			this.pluginServices.notifyError("unknown");
+			return {
+				success: false,
+				message: "",
+				error: "An unexpected error occurred.",
+			};
+		}
+	}
+
+	public async getGptStreamingResponse(
+		payload: GptRequestPayload,
+		editor: Editor
+	): Promise<void> {
+		const apiKey = this.settings.openaiApiKey;
+		const apiUrl = this.settings.openaiChatUrl;
+
+		const requestOptions = {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${apiKey}`,
+			},
+			body: JSON.stringify(payload),
+		};
+
+		try {
+			const response = await fetch(apiUrl, requestOptions);
+			if (!response.body) {
+				return;
+			}
+
+			const reader = response.body.getReader();
+			const decoder = new TextDecoder();
+			let isReading = true;
+			let lineNum = editor.getCursor().line;
+			let charNum = editor.getCursor().ch;
+			let paragraphText = "";
+
+			let x = 0;
+
+			while (isReading) {
+				if (x > 500) {
+					isReading = false;
+					console.error("BOOM! Reached limit.");
+					break;
+				}
+				x++;
+				const { done, value } = await reader.read();
+				if (done) {
+					isReading = false;
+					break;
+				}
+				const chunkText = decoder.decode(value, { stream: true });
+				// Some of this is based on the example from @schnerd's comment here:
+				// https://github.com/openai/openai-node/issues/18#issuecomment-1369996933
+				const jsonLines = chunkText
+					.split("\n")
+					.filter((line) => line.trim() !== "");
+				for (const jsonLine of jsonLines) {
+					const message = jsonLine.replace(/^data: /, "");
+					if (message === "[DONE]") {
+						break;
+					}
+					try {
+						const parsed = JSON.parse(message);
+						if (parsed.choices[0]?.delta?.content) {
+							const word: string = parsed.choices[0].delta.content.toString();
+
+							paragraphText += word;
+							charNum = paragraphText.length - word.length;
+
+							editor.replaceRange(word, {
+								line: lineNum,
+								ch: charNum,
+							});
+
+							const numReturns: number = [...word.matchAll(/\n/g)].length;
+							if (numReturns) {
+								paragraphText = "";
+								lineNum += numReturns;
+								charNum = 0;
+							}
+						}
+					} catch (error) {
+						console.error(
+							"Could not JSON parse stream message",
+							message,
+							error
+						);
+					}
+					editor.setCursor({
+						line: lineNum + 1,
+						ch: 0,
+					});
+				}
+			}
+		} catch (error) {
+			console.error("Fetch error:", error);
+		}
+	}
+
+	// Generates payload and gets a streaming response for "On This Date..."
+	async onThisDate(editor: Editor): Promise<void> {
+		if (!this.hasApiKey()) {
+			this.pluginServices.notifyError("noApiKey");
+			return;
+		}
+
+		const gptModel = this.settings.openaiModel;
+		const today = new Date().toLocaleDateString("en-US", {
+			month: "long",
+			day: "numeric",
+		});
+
+		const payload: GptRequestPayload = {
+			model: gptModel,
+			messages: [
+				{
+					role: "user",
+					content: `Tell me one thing from history in one paragraph that's
+						interesting, significant, or funny that happened on ${today}.`,
+				},
+			],
+			stream: true,
+			temperature: 0.7,
+		};
+
+		this.getGptStreamingResponse(payload, editor);
+	}
+
+	// Keeping this for now as a reference for standard requests
+
+	// Generates payload and gets a standard response for "On This Date..." feature
+	// async onThisDate(): Promise<string> {
+	// 	if (!this.hasApiKey()) {
+	// 		this.pluginServices.notifyError("noApiKey");
+	// 		return "";
+	// 	}
+
+	// 	const gptModel = this.settings.openaiModel;
+	// 	const today = new Date().toLocaleDateString("en-US", {
+	// 		month: "long",
+	// 		day: "numeric",
+	// 	});
+
+	// 	const payload: GptRequestPayload = {
+	// 		model: gptModel,
+	// 		messages: [
+	// 			{
+	// 				role: "user",
+	// 				content: `Tell me something interesting, significant, or funny
+	// 					from history that happened on ${today}.`,
+	// 			},
+	// 		],
+	// 		stream: true,
+	// 		temperature: 0.7,
+	// 	};
+
+	// 	const response = await this.getGptChatResponse(payload);
+	// 	if (!response.success) {
+	// 		return "";
+	// 	}
+	// 	return response.message;
+	// }
+
+	// Generates payload and gets a joke response from the GPT chat API
+	async getAJoke(): Promise<string> {
+		if (!this.hasApiKey()) {
+			this.pluginServices.notifyError("noApiKey");
+			return "";
+		}
+
+		const gptModel = this.settings.openaiModel;
+		const payload: GptRequestPayload = {
+			model: gptModel,
+			messages: [
+				{
+					role: "user",
+					content: "Tell me a joke in the style of Louis CK.",
+				},
+			],
+			temperature: 0.7,
+		};
+
+		const response = await this.getGptChatResponse(payload);
+		if (!response.success) {
+			return "";
+		}
+		return response.message;
+	}
+
+	hasApiKey(): boolean {
+		return !!this.settings.openaiApiKey;
+	}
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,0 +1,28 @@
+import { WorkspaceLeaf } from "obsidian";
+
+export interface IPluginServices {
+  activateView(): Promise<WorkspaceLeaf | null>;
+  notifyError(errorCode: string): void;
+}
+
+export interface GptEngines {
+	id: string;
+	ready: boolean;
+	owner: string;
+}
+
+export interface GptRequestPayload {
+	model: string;
+	messages: {
+		role: "user" | "system";
+		content: string;
+	}[];
+	stream?: boolean;
+	temperature: number;
+}
+
+export interface GptChatResponse {
+	success: boolean;
+	message: string;
+	error?: string;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,20 +1,24 @@
 import { Editor, MarkdownView, Notice, Plugin, WorkspaceLeaf } from "obsidian";
+import { GPT_VIEW_TYPE, ErrorCode, ERROR_MESSAGES } from "@/constants";
+import { IPluginServices } from "@/interfaces";
 import {
 	GptPluginSettings,
 	GptSettingsTab,
 	DEFAULT_SETTINGS,
 } from "@/settings";
-import { GptModal, GptGetPromptModal } from "@/modals";
-import { ERROR_MESSAGES, ErrorCode, GPT_VIEW_TYPE } from "@/constants";
-import GptView from "@/view";
+import { GptTextOutputModal, GptGetPromptModal } from "@/modals";
+import ApiService from "@/apiService";
+import { GptView } from "@/view";
 
-export default class GptPlugin extends Plugin {
+export default class GptPlugin extends Plugin implements IPluginServices {
 	settings: GptPluginSettings;
+	apiService: ApiService;
 	apiKey?: string;
 	gptModel?: string;
 
 	async onload(): Promise<void> {
 		await this.loadSettings();
+		this.apiService = new ApiService(this.app, this, this.settings);
 
 		// This adds a settings tab so the user can configure
 		// various aspects of the plugin
@@ -35,7 +39,7 @@ export default class GptPlugin extends Plugin {
 
 		// Get Engines Icon
 		this.addRibbonIcon("bot", "Get GPT Robots", (evt: MouseEvent) => {
-			this.getEngines();
+			this.apiService.getEngines();
 		});
 
 		// Send selected text with instruction from modal
@@ -47,10 +51,10 @@ export default class GptPlugin extends Plugin {
 				editor: Editor,
 				view: MarkdownView
 			) => {
-				const selectedText = editor.getSelection();
+				const selectedText = editor.getSelection().trim();
 				if (selectedText) {
 					if (!checking) {
-						this.sendSelectedWithInstructions(selectedText);
+						new GptGetPromptModal(this.app, selectedText, this.apiService).open();
 					}
 					return true;
 				}
@@ -63,8 +67,8 @@ export default class GptPlugin extends Plugin {
 			id: "gpt-joke-modal",
 			name: "Tell me a joke",
 			callback: async () => {
-				const joke = await this.getAJoke();
-				new GptModal(this.app, joke).open();
+				const joke = await this.apiService.getAJoke();
+				new GptTextOutputModal(this.app, joke).open();
 			},
 		});
 
@@ -74,23 +78,13 @@ export default class GptPlugin extends Plugin {
 			name: "On This Date...",
 			hotkeys: [{ modifiers: ["Mod", "Shift"], key: "d" }],
 			editorCallback: async (editor: Editor) => {
-				await this.onThisDate(editor);
+				await this.apiService.onThisDate(editor);
 			},
 		});
 	}
 
-	// UTILITIES
-	hasApiKey(): boolean {
-		return !!this.settings.openaiApiKey;
-	}
-
-	notifyError(errorCode: ErrorCode): void {
-		const errorMessage = ERROR_MESSAGES[errorCode] || ERROR_MESSAGES.unknown;
-		new Notice(errorMessage);
-	}
-
 	// VIEW
-	async activateView(): Promise<WorkspaceLeaf | null> {
+	public async activateView(): Promise<WorkspaceLeaf | null> {
 		const { workspace } = this.app;
 		let leaf: WorkspaceLeaf | null =
 			workspace.getLeavesOfType(GPT_VIEW_TYPE)[0];
@@ -114,249 +108,6 @@ export default class GptPlugin extends Plugin {
 		return null;
 	}
 
-	// API CALLS
-
-	// Send selected text with instructions from modal
-	async sendSelectedWithInstructions(selectedText: string): Promise<void> {
-		new GptGetPromptModal(this.app, selectedText).open();
-	}
-
-	// Engine endpoint
-	async getEngines(): Promise<string[]> {
-		if (!this.hasApiKey()) {
-			this.notifyError("noApiKey");
-			return [ERROR_MESSAGES.noApiKey];
-		}
-
-		const leaf = await this.activateView();
-		if (!leaf) {
-			console.error(ERROR_MESSAGES.viewError);
-			return [ERROR_MESSAGES.viewError];
-		}
-
-		const apiKey = this.settings.openaiApiKey;
-		const apiUrl = this.settings.openaiEnginesUrl;
-
-		try {
-			// No need to import fetch; it's globally available in Node.js 17.5+.
-			const response = await fetch(apiUrl, {
-				method: "GET",
-				headers: {
-					Authorization: `Bearer ${apiKey}`,
-				},
-			});
-
-			// Assuming the API returns JSON
-			const data = await response.json();
-			const engines: string[] = data.data
-				.map((engine: GptEngines) => engine.id)
-				.sort();
-			console.table(engines);
-			if (leaf.view instanceof GptView) {
-				leaf.view.updateEngines(engines);
-			}
-			return engines;
-		} catch (error) {
-			this.notifyError("noEngines");
-			console.error("Error:", error);
-			return [ERROR_MESSAGES.noEngines];
-		}
-	}
-
-	// Generic function to get a response from the GPT chat API based on a payload
-	async getGptChatResponse(
-		payload: GptRequestPayload
-	): Promise<GptChatResponse> {
-		const apiKey = this.settings.openaiApiKey;
-		const apiUrl = this.settings.openaiChatUrl;
-
-		try {
-			const response = await fetch(apiUrl, {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-					Authorization: `Bearer ${apiKey}`,
-				},
-				body: JSON.stringify(payload),
-			});
-
-			if (!response.ok) {
-				return {
-					success: false,
-					message: "",
-					error: `HTTP error status: ${response.status}`,
-				};
-			}
-
-			const data = await response.json();
-
-			return { success: true, message: data.choices[0].message.content };
-		} catch (error) {
-			console.error("Error:", error);
-			this.notifyError("unknown");
-			return {
-				success: false,
-				message: "",
-				error: "An unexpected error occurred.",
-			};
-		}
-	}
-
-	async getGptStreamingResponse(
-		payload: GptRequestPayload,
-		editor: Editor
-	): Promise<void> {
-		const apiKey = this.settings.openaiApiKey;
-		const apiUrl = this.settings.openaiChatUrl;
-
-		const requestOptions = {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-				Authorization: `Bearer ${apiKey}`,
-			},
-			body: JSON.stringify(payload),
-		};
-
-		try {
-			const response = await fetch(apiUrl, requestOptions);
-			if (!response.body) {
-				return;
-			}
-
-			const reader = response.body.getReader();
-			const decoder = new TextDecoder();
-			let isReading = true;
-
-			while (isReading) {
-				const { done, value } = await reader.read();
-				if (done) {
-					isReading = false;
-					break;
-				}
-				const chunkText = decoder.decode(value, { stream: true });
-				// Some of this is based on the example from @schnerd's comment here:
-				// https://github.com/openai/openai-node/issues/18#issuecomment-1369996933
-				const lines = chunkText
-					.split("\n")
-					.filter((line) => line.trim() !== "");
-				for (const line of lines) {
-					const message = line.replace(/^data: /, "");
-					if (message === "[DONE]") {
-						break;
-					}
-					try {
-						const parsed = JSON.parse(message);
-						if (parsed.choices[0]?.delta?.content) {
-							editor.replaceRange(parsed.choices[0].delta.content, {
-								line: editor.lineCount(),
-								ch: 0,
-							});
-						}
-					} catch (error) {
-						console.error(
-							"Could not JSON parse stream message",
-							message,
-							error
-						);
-					}
-				}
-			}
-		} catch (error) {
-			console.error("Fetch error:", error);
-		}
-	}
-
-	// Generates payload and gets a streaming response for "On This Date..."
-	async onThisDate(editor: Editor): Promise<void> {
-		if (!this.hasApiKey()) {
-			this.notifyError("noApiKey");
-			return;
-		}
-
-		const gptModel = this.settings.openaiModel;
-		const today = new Date().toLocaleDateString("en-US", {
-			month: "long",
-			day: "numeric",
-		});
-
-		const payload: GptRequestPayload = {
-			model: gptModel,
-			messages: [
-				{
-					role: "user",
-					content: `Tell me something positive and happy from history
-					  that happened on ${today}.`,
-				},
-			],
-			stream: true,
-			temperature: 0.7,
-		};
-
-		this.getGptStreamingResponse(payload, editor);
-	}
-
-	// Keeping this for now as a reference for standard requests
-
-	// Generates payload and gets a standard response for "On This Date..." feature
-	// async onThisDate(): Promise<string> {
-	// 	if (!this.hasApiKey()) {
-	// 		this.notifyError("noApiKey");
-	// 		return "";
-	// 	}
-
-	// 	const gptModel = this.settings.openaiModel;
-	// 	const today = new Date().toLocaleDateString("en-US", {
-	// 		month: "long",
-	// 		day: "numeric",
-	// 	});
-
-	// 	const payload: GptRequestPayload = {
-	// 		model: gptModel,
-	// 		messages: [
-	// 			{
-	// 				role: "user",
-	// 				content: `Tell me something interesting, significant, or funny
-	// 					from history that happened on ${today}.`,
-	// 			},
-	// 		],
-	// 		stream: true,
-	// 		temperature: 0.7,
-	// 	};
-
-	// 	const response = await this.getGptChatResponse(payload);
-	// 	if (!response.success) {
-	// 		return "";
-	// 	}
-	// 	return response.message;
-	// }
-
-	// Generates payload and gets a joke response from the GPT chat API
-	async getAJoke(): Promise<string> {
-		if (!this.hasApiKey()) {
-			this.notifyError("noApiKey");
-			return "";
-		}
-
-		const gptModel = this.settings.openaiModel;
-		const payload: GptRequestPayload = {
-			model: gptModel,
-			messages: [
-				{
-					role: "user",
-					content: "Tell me a joke in the style of Louis CK.",
-				},
-			],
-			temperature: 0.7,
-		};
-
-		const response = await this.getGptChatResponse(payload);
-		if (!response.success) {
-			return "";
-		}
-		return response.message;
-	}
-
 	onunload(): void {
 		this.app.workspace.detachLeavesOfType(GPT_VIEW_TYPE);
 	}
@@ -376,28 +127,9 @@ export default class GptPlugin extends Plugin {
 	async saveSettings(): Promise<void> {
 		await this.saveData(this.settings);
 	}
-}
 
-// INTERFACES
-
-interface GptEngines {
-	id: string;
-	ready: boolean;
-	owner: string;
-}
-
-interface GptRequestPayload {
-	model: string;
-	messages: {
-		role: "user" | "system";
-		content: string;
-	}[];
-	stream?: boolean;
-	temperature: number;
-}
-
-interface GptChatResponse {
-	success: boolean;
-	message: string;
-	error?: string;
+	public notifyError(errorCode: ErrorCode): void {
+		const errorMessage = ERROR_MESSAGES[errorCode] || ERROR_MESSAGES.unknown;
+		new Notice(errorMessage);
+	}
 }

--- a/src/modals.tsx
+++ b/src/modals.tsx
@@ -1,7 +1,8 @@
 import { App, Modal } from "obsidian";
 import { h, render } from "preact";
+import ApiService from "@/apiService";
 
-export class GptModal extends Modal {
+export class GptTextOutputModal extends Modal {
 	gptText: string;
 
 	constructor(app: App, gptText: string) {
@@ -19,22 +20,28 @@ export class GptModal extends Modal {
 }
 
 export class GptGetPromptModal extends Modal {
-	prompt: string;
+	selectedText: string;
+	promptValue: string;
+	apiService: ApiService;
 
-	constructor(app: App, prompt: string) {
+	constructor(app: App, selectedText: string, apiService: ApiService) {
 		super(app);
-		this.prompt = prompt;
+		this.selectedText = selectedText;
+		this.apiService = apiService;
 	}
-
+	
 	onOpen() {
+		this.setTitle("How can I help you with your highlighted text?");
+
 		render(
-			<div>
-				<h3>How can I help you with your highlighted text?</h3>
+			<div id="gpt-prompt-modal">
 				<textarea
-					className="prompt-input"
+					className="gpt-prompt-input"
 					placeholder="Questions? Instructions?"
+					rows={6}
+					onInput={(e: Event) => this.handleInput(e)}
 				/>
-				<button>Submit</button>
+				<button onClick={this.handleSendPrompt}>Send</button>
 			</div>,
 			this.contentEl
 		);
@@ -44,5 +51,19 @@ export class GptGetPromptModal extends Modal {
 		const { contentEl } = this;
 		contentEl.empty();
 	}
+
+	handleInput = (e: Event) => {
+		const target = e.target as HTMLTextAreaElement;
+		this.promptValue = target.value.trim();
+	};
+
+	handleSendPrompt = () => {
+		const promptAndSelectedText =
+			`Prompt:\n\n${this.promptValue}\n` +
+			`___\n\n` +
+			`Selected Text:\n\n${this.selectedText}`;
+		console.log(promptAndSelectedText);
+		this.apiService.sendPromptWithSelectedText(promptAndSelectedText);
+		this.close();
+	};
 }
-	

--- a/src/view.tsx
+++ b/src/view.tsx
@@ -1,9 +1,11 @@
 import { ItemView, Notice, WorkspaceLeaf } from "obsidian";
 import { ERROR_MESSAGES, GPT_VIEW_TYPE } from "@/constants";
 import { h, Fragment, render } from "preact";
+import ApiService from "./apiService";
 
-export default class GptView extends ItemView {
+export class GptView extends ItemView {
 	engines: string[] = [];
+	apiService: ApiService;
 
 	constructor(leaf: WorkspaceLeaf) {
 		super(leaf);
@@ -29,6 +31,12 @@ export default class GptView extends ItemView {
 			</>,
 			root
 		);
+	}
+
+	renderSelectedTextResponse(selectedTextResponse: string, container: HTMLElement) {
+		if (selectedTextResponse.length > 0) {
+			container.innerText += selectedTextResponse;
+		}
 	}
 
 	renderEngines(container: HTMLElement) {

--- a/styles.css
+++ b/styles.css
@@ -15,10 +15,34 @@ If your plugin does not need CSS, delete this file.
   opacity: 0.9;
   padding: 1rem;
   width: 100%;
-  border-bottom: 1px solid gray;
+  border-bottom: 1px solid var(--color-base-30);
 }
 
-/* .prompt-input {
-  width: 20rem;
-  height: 
-} */
+#gpt-prompt-modal {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+#gpt-prompt-modal > button {
+  margin-left: auto;
+  margin-top: var(--size-4-4);
+}
+
+.gpt-prompt-input {
+  width: 100%;
+  flex-grow: 1;
+  min-height: 6em;
+  overflow: auto;
+}
+
+.gpt-msg-container {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--color-base-50);
+  user-select: text;
+  -webkit-user-select: text;
+}


### PR DESCRIPTION
- Add a command that appears only when text is selected. This command should be named something like "Send selected text with instructions"
- When command is selected, open a modal dialog box to allow the user to enter a custom prompt to send to the GPT API.
- Construct and make the API payload combining the user's selected text with their entered prompt.
- Display the API's response in the plugin's right-side view