### PR TITLE
Distinct User and GPT Messages in GPT View

### DIFF
--- a/src/Message.tsx
+++ b/src/Message.tsx
@@ -1,26 +1,40 @@
 import ReactMarkdown from "react-markdown";
+import { MessageType } from "./Messages";
 
-interface MessageProps {
-	message: string;
-}
-
-// Message properties could be:
-// id: number
-// role: string
-// type: string
-// content: string
-// model: string
-// actions: string
-// status: string
-// error: string
-// ...
-
-const Message: React.FC<MessageProps> = ({ message }) => {
+const Message: React.FC<MessageType> = ({
+	id,
+	role,
+	message,
+	model,
+	error,
+	// actions,
+	// status,
+}) => {
 	return (
 		<>
 			{message ? (
-				<div className="gpt-message">
-					<ReactMarkdown>{message}</ReactMarkdown>
+				<div className={`gpt-message gpt-message-${role}`}>
+					{error ? (
+						<div className="gpt-message-error">{error}</div>
+					) : (
+						<ReactMarkdown>{message}</ReactMarkdown>
+					)}
+					{model && role === "system" && (
+						<div className="gpt-message-model">{model}</div>
+					)}
+					{/* {actions && actions.length > 0 && (
+						<div className="gpt-message-actions">
+							{actions.map((action, index) => (
+								<button
+									key={index}
+									className="gpt-message-action"
+									onClick={() => console.log(action)}
+								>
+									{action}
+								</button>
+							))}
+						</div>
+					)} */}
 				</div>
 			) : null}
 		</>

--- a/src/apiService.ts
+++ b/src/apiService.ts
@@ -35,7 +35,7 @@ export default class ApiService {
 
 		try {
 			// Add a new <Message /> component to the list of messages
-			emitter.emit("newMessage");
+			emitter.emit("newMessage", "system");
 
 			const response = await fetch(apiUrl, requestOptions);
 			if (!response.body) {
@@ -171,7 +171,6 @@ export default class ApiService {
 
 	async renderToEditor(text: string, editor: Editor): Promise<void> {
 		return new Promise((resolve) => {
-			console.log(text);
 			let { line, ch } = editor.getCursor();
 			// Without a leading space, the markdown rendering timing
 			// causes issues with the cursor position

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -24,31 +24,3 @@ export interface GptRequestPayload {
 	stream?: boolean;
 	temperature: number;
 }
-
-export interface GptChatResponse {
-	success: boolean;
-	message: string;
-	error?: string;
-}
-
-export interface OpenAIAPIResponse {
-	body: ReadableStream<Uint8Array> | null;
-	ok: boolean;
-	status: number;
-	statusText: string;
-	url: string;
-}
-
-export interface FeatureProperties {
-	id: string;
-	buildPrompt: (inputText?: string) => string;
-	processResponse: (
-		response: string,
-		container?: ContainerType,
-		gptView?: GptView
-	) => void;
-	model?: string;
-	temperature?: number;
-	stream?: boolean;
-	container?: ContainerType;
-}

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,10 +28,10 @@ export default class GptPlugin extends Plugin implements IPluginServices {
 		// Add a view to the app
 		this.registerView(
 			GPT_VIEW_TYPE,
-			(leaf: WorkspaceLeaf) => new GptView(leaf)
+			(leaf: WorkspaceLeaf) => new GptView(leaf, this.apiService, this.settings)
 		);
 
-		// ICONS AND COMMANDS
+		// RIBBON AND COMMANDS
 
 		// Chat with GPT icon
 		this.addRibbonIcon("message-square", "Chat with GPT", (evt: MouseEvent) => {
@@ -135,7 +135,6 @@ export default class GptPlugin extends Plugin implements IPluginServices {
 	}
 
 	// DATA STORAGE
-
 	// Loads the default settings, and then overrides them with
 	// any saved settings
 	async loadSettings(): Promise<void> {
@@ -151,6 +150,7 @@ export default class GptPlugin extends Plugin implements IPluginServices {
 		await this.saveData(this.settings);
 	}
 
+	// MISCELLANEOUS
 	notifyError(errorCode: ErrorCode, consoleMsg?: string): void {
 		const errorMessage = ERROR_MESSAGES[errorCode] || ERROR_MESSAGES.unknown;
 		new Notice(errorMessage);

--- a/src/modals.tsx
+++ b/src/modals.tsx
@@ -2,9 +2,7 @@ import { App, Modal } from "obsidian";
 import { Root, createRoot } from "react-dom/client";
 import PromptModalContent from "@/PromptModalContent";
 
-// =============================================================================
 // GET PROMPT FROM USER MODAL ==================================================
-// =============================================================================
 export class GptPromptModal extends Modal {
 	private modalRoot: Root | null = null;
 	private promptValue: string;
@@ -42,10 +40,11 @@ export class GptPromptModal extends Modal {
 		};
 
 		const handleSend = () => {
-			let prompt = `User Prompt:\n\n${this.promptValue}`;
+			let prompt = "";
 			if (this.selectedText) {
-				prompt += `\n\nUser Selected Text:\n\n${this.selectedText}`;
+				prompt += `${this.selectedText}\n___\n`;
 			}
+			prompt += this.promptValue;
 			this.close();
 			this.onSend(prompt);
 		};
@@ -68,9 +67,7 @@ export class GptPromptModal extends Modal {
 	}
 }
 
-// =============================================================================
 // SIMPLE TEXT OUTPUT MODAL ====================================================
-// =============================================================================
 export class GptTextOutputModal extends Modal {
 	gptText: string;
 	modalRoot: Root | null = null;

--- a/src/view.tsx
+++ b/src/view.tsx
@@ -9,9 +9,9 @@ import ApiService from "@/apiService";
 import Messages from "@/Messages";
 
 export default class GptView extends ItemView {
-	private apiService: ApiService;
-	private settings: GptPluginSettings;
-	private pluginServices: IPluginServices;
+	apiService: ApiService;
+	settings: GptPluginSettings;
+	pluginServices: IPluginServices;
 	root: Root | null = null;
 	message: string;
 	responseStream: string;
@@ -19,9 +19,16 @@ export default class GptView extends ItemView {
 
 	static instance: GptView;
 
-	constructor(leaf: WorkspaceLeaf) {
+	constructor(
+		leaf: WorkspaceLeaf,
+		apiService: ApiService,
+		settings: GptPluginSettings
+	) {
 		super(leaf);
 		GptView.instance = this;
+		this.apiService = apiService;
+		this.settings = settings;
+		this.pluginServices = apiService.pluginServices;
 	}
 
 	getViewType(): string {
@@ -37,6 +44,7 @@ export default class GptView extends ItemView {
 	}
 
 	async onOpen(): Promise<void> {
+		console.clear();
 		const root = createRoot(this.containerEl.children[1]);
 		this.root = root;
 

--- a/styles.css
+++ b/styles.css
@@ -11,15 +11,27 @@
 	border-bottom: 1px solid var(--color-base-30);
 }
 .gpt-messages {
-	padding: 1rem;
+	padding: .5rem .5rem 5rem;
 }
 .gpt-message {
 	display: flex;
 	flex-direction: column;
-	padding: 0 0 1rem 0;
-	border-bottom: 1px solid var(--color-base-50);
+	padding: .25rem 1.5rem 1rem;
+	border-radius: 1rem;
 	user-select: text;
 	-webkit-user-select: text;
+}
+.gpt-message-user {
+	/* margin-bottom: 1rem; */
+}
+.gpt-message-system {
+	background: var(--background-primary);
+	opacity: 0.9;
+}
+.gpt-message-model {
+	color: var(--color-base-40);
+	font-size: small;
+	text-align: right;
 }
 
 /* Modals */


### PR DESCRIPTION
As someone using the plugin, I want to see both my prompts and the GPT responses in the GPT view, with each message being visually distinct according to its source (me or GPT). This will enhance the clarity and usability of the chat interface by clearly differentiating between my inputs and the AI's outputs.

**Tasks:**
- [x] **Review Current Message Handling:** Examine the existing implementation to understand how messages are currently processed and displayed.
- [x] **Define Message Types:** Create a structure to differentiate between user prompts and GPT responses, including metadata to indicate the source.
- [x] **Update Rendering Logic:** Modify the rendering logic to handle and display both user prompts and GPT responses as distinct messages.
- [x] **Style Messages by Author:** Apply CSS styles to visually distinguish between user prompts and GPT responses, ensuring clear differentiation.
- [x] **Test User Prompt Rendering:** Implement and test the rendering of user prompts in the GPT view to ensure they appear correctly and distinctly.
- [x] **Integrate with Existing System:** Ensure that the new implementation seamlessly integrates with the existing message handling system.
- [x] **Testing:** Conduct thorough testing to verify that both user prompts and GPT responses are displayed correctly and distinctly in various scenarios.