### PR TITLE
Include Previous Messages in Payload (#49)

### DIFF
--- a/src/PayloadMessages.ts
+++ b/src/PayloadMessages.ts
@@ -4,15 +4,18 @@ class PayloadMessages {
 	payloadMessages: PayloadMessagesType[];
 
 	constructor() {
-		this.payloadMessages = this.payloadMessages || [];
+		this.payloadMessages = [];
 	}
 
 	getPayloadMessages(): PayloadMessagesType[] {
 		return this.payloadMessages;
 	}
 
+	getLatestPayloadMessage(): PayloadMessagesType {
+		return this.payloadMessages[this.payloadMessages.length - 1];
+	}
+
 	addMessage(message: PayloadMessagesType): PayloadMessagesType[] {
-		// console.log(message);
 		this.payloadMessages.push(message);
 		return this.payloadMessages;
 	}

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -11,7 +11,6 @@ const Message: React.FC<MessageType> = ({
 	// actions,
 	// status,
 }) => {
-	if (message && role === "user") message = "**&raquo;** " + message;
 	return (
 		<>
 			{message ? (

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -34,10 +34,7 @@ const Messages: React.FC = () => {
 	useEffect(() => {
 		// Adds a new message. When a new message prompt is initiated,
 		// a new message is added to the messages array.
-		const handleNewMessage = (
-			role: Role,
-			selectedText: string
-		) => {
+		const handleNewMessage = (role: Role, selectedText: string) => {
 			const newMessage: MessageType = {
 				id: generateUniqueId(),
 				role: role,
@@ -53,6 +50,12 @@ const Messages: React.FC = () => {
 		};
 		emitter.on("newMessage", handleNewMessage);
 
+		return () => {
+			emitter.off("newMessage", handleNewMessage);
+		};
+	}, []);
+
+	useEffect(() => {
 		// Update the most recent message with streaming content from the API.
 		const handleUpdateMessage = (response: string) => {
 			if (latestMessageRef.current) {
@@ -68,21 +71,22 @@ const Messages: React.FC = () => {
 		};
 		emitter.on("updateMessage", handleUpdateMessage);
 
+		return () => {
+			emitter.off("updateMessage", handleUpdateMessage);
+		};
+	}, []);
+
+	useEffect(() => {
 		// Add message after API response
-		const handleAddMessage = (
-			role: Role,
-			content: "string"
-		) => {
+		const handleAddMessage = (role: Role, content: "string") => {
 			if (latestMessageRef.current) {
 				latestMessageRef.current.role = role;
 				latestMessageRef.current.content = content;
-				console.log(latestMessageRef.current);
 				setMessages((prevMessages) => {
 					const updatedMessages = [...prevMessages];
 					updatedMessages[updatedMessages.length - 1] = {
 						...(latestMessageRef.current as MessageType),
 					};
-					console.log(updatedMessages);
 					return updatedMessages;
 				});
 			}
@@ -90,11 +94,9 @@ const Messages: React.FC = () => {
 		emitter.on("addMessage", handleAddMessage);
 
 		return () => {
-			emitter.off("newMessage", handleNewMessage);
-			emitter.off("updateMessage", handleUpdateMessage);
 			emitter.off("addMessage", handleAddMessage);
 		};
-	}, [settings]);
+	}, []);
 
 	return (
 		<div className="gpt-messages">

--- a/src/components/PluginContext.tsx
+++ b/src/components/PluginContext.tsx
@@ -1,4 +1,5 @@
-import { StrictMode, createContext, useContext } from "react";
+// import { StrictMode, createContext, useContext } from "react";
+import { createContext, useContext } from "react";
 import { GptPluginSettings } from "@/settings";
 import { IPluginServices } from "@/interfaces";
 
@@ -23,7 +24,8 @@ export default function PluginContextProvider({
 
 	return (
 		<PluginContext.Provider value={{ settings, pluginServices }}>
-			<StrictMode>{children}</StrictMode>
+			{/* <StrictMode>{children}</StrictMode> */}
+			{children}
 		</PluginContext.Provider>
 	);
 }

--- a/src/components/modals.tsx
+++ b/src/components/modals.tsx
@@ -27,8 +27,7 @@ export class GptPromptModal extends Modal {
 		);
 
 		const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-			const target = e.target as HTMLTextAreaElement;
-			this.promptValue = target.value.trim();
+			this.promptValue = e.target.value.trim();
 		};
 
 		const handleKeyPress = (e: React.KeyboardEvent) => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,9 +40,17 @@ export const PROMPTS = {
 			"response with 2 newline chars, 3 underscores, and 2 more newline chars, " +
 			"i.e. `\n\n___\n\n`.",
 	},
+	define: {
+		role: "user",
+		content: '<= Define this term in the following format:\n' +
+			'**<term>** `<Pronunciation in International Phonetic Alphabet (IPA)>`\n' +
+			'<Definition, or if more than one, enumerated definitions>\n' +
+			'- *Example*: "<Use the term in a sentence>"',
+	},
 	tellAJoke: {
 		role: "user",
 		content:
 			"Tell me a joke (and only the joke) in the style of Anthony Jeselnik.",
 	},
 };
+

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,9 +1,5 @@
-import { Editor } from "obsidian";
-import { GptTextOutputModal } from "@/components/modals";
 import { PayloadMessagesType } from "@/components/Messages";
 import GptView from "@/components/view";
-
-export type ContainerType = HTMLElement | Editor | GptTextOutputModal | GptView;
 
 export interface IPluginServices {
 	toggleView(): Promise<GptView | null>;

--- a/src/promptBuilder.ts
+++ b/src/promptBuilder.ts
@@ -1,19 +1,19 @@
 export interface Prompt {
-  inputText?: string;
-  selectedText?: string;
-  formattingGuidance?: string;
+	inputText?: string;
+	selectedText?: string;
+	formattingGuidance?: string;
 }
 
-export const buildPrompt = ({ inputText, selectedText, formattingGuidance }: Prompt): string => {
-  let prompt = "";
-  if (selectedText) {
-    prompt += `${selectedText}\n\n`;
-  }
-  if (inputText) {
-    prompt += `${inputText}\n\n`;
-  }
-  if (formattingGuidance) {
-    prompt += formattingGuidance;
-  }
-  return prompt;
-}
+export const buildPrompt = ({
+	inputText,
+	selectedText,
+	formattingGuidance,
+}: Prompt): string => {
+	const prompt = [selectedText, inputText, formattingGuidance].filter(Boolean);
+	
+	// I don't know why I have to have the following interim
+	// variable, but it doesn't work without it.
+	const promptStr = prompt.join("\n\n").trim();
+
+	return promptStr;
+};

--- a/styles.css
+++ b/styles.css
@@ -1,18 +1,19 @@
 /* View */
 .gpt-view-title {
-	position: sticky;
+	position: absolute;
 	top: 0;
 	left: 0;
 	z-index: 1000; /* Ensures the header is above other content */
 	background: var(--background-primary);
-	opacity: 0.9;
+	opacity: 0.88;
 	margin-block-start: 0;
-	padding: 0.4rem 1rem;
+	padding: 0.33rem 1rem 0.5rem;
 	width: 100%;
 	font-weight: 400;
 }
 .gpt-messages {
-	padding: 0.5rem 0.5rem 5rem;
+	padding: 1rem 0.5rem 5rem;
+	font-size: small;
 }
 .gpt-message {
 	display: flex;
@@ -22,27 +23,51 @@
 	user-select: text;
 	-webkit-user-select: text;
 }
+.gpt-message p {
+	position: relative;
+	margin-bottom: auto;
+	/* Respect line breaks */
+	white-space: pre-wrap;
+}
 .gpt-message pre {
-	padding: 0.5rem;
 	overflow: scroll;
 	background: var(--background-secondary);
-	font-size: small;
+	font-size: smaller;
+	margin-top: 1.25rem;
 	border: 1px solid rgba(255, 255, 255, 0.2);
+	border-radius: 0.5rem;
 }
-
+.gpt-message code[class*="language-"],
+.gpt-message code {
+	white-space: pre;
+	color: var(--em-color);
+}
 .gpt-message-user {
-	margin-top: 1rem;
+	margin-top: 0.5rem;
+}
+.gpt-message-user > p:first-of-type::before {
+	/* margin-right: 0.33rem; */
+	position: absolute;
+	content: "» ";
+	font-weight: bold;
+	font-size: larger;
+	color: var(--strong-color);
+	margin-left: -1rem;
+	/* margin-top: -0.15rem; */
+	line-height: 0.9;
 }
 .gpt-message-assistant {
+	margin-top: 0.33rem;
+	border: 1px solid var(--background-modifier-border);
 	background: var(--background-primary);
 	opacity: 0.9;
 }
 
 .gpt-message-selectedtext {
-	/* color: var(--color-base-40); */
-	border-left: 3px solid var(--color-base-30);
+	border-left: 3px solid var(--background-modifier-border);
 	padding: 0.25rem 0 0.25rem 1rem;
-	margin: 0.25rem auto 0.5rem;
+	margin-top: 0.75rem;
+	margin-bottom: 0.5rem;
 }
 
 /* Start WDS technique */
@@ -52,8 +77,8 @@
 	display: block;
 	--max-lines: 5;
 	line-height: var(--line-height-tight);
-	max-height: calc(var(--max-lines) * 1em * var(--line-height-tight));
-	max-height: 5em;
+	/* max-height: calc(var(--max-lines) * 1em * var(--line-height-tight)); */
+	max-height: 5rem;
 	overflow: hidden;
 	position: relative;
 	mask-image: linear-gradient(to top, transparent, black 2rem);
@@ -73,13 +98,14 @@
 	max-height: none;
 	mask-image: none;
 	-webkit-mask-image: none;
+	/* cursor: auto; */ /* Not sure about this. Has trade offs. */
 }
 /* End WDS technique */
 
 /* Model */
 .gpt-message-model {
 	color: var(--color-base-40);
-	font-size: small;
+	font-size: smaller;
 	text-align: right;
 }
 


### PR DESCRIPTION
As a plugin user, I would like previous chat messages to be included in the payload sent to the system, so that the context of the conversation is maintained and responses are more coherent.

**Tasks**

- [x] Modify the payload structure to include previous chat messages.
- [x] Ensure that the message history is correctly appended to each new message sent.
- [x] Send `system` message at the beginning of a new chat session
- [x] Test the new payload structure to verify that conversation context is accurately maintained and reflected in responses.