### PR TITLE
Replace Chat Bar Name with Icon

### DIFF
--- a/src/components/view.tsx
+++ b/src/components/view.tsx
@@ -1,4 +1,4 @@
-import { ItemView, WorkspaceLeaf } from "obsidian";
+import { ItemView, setIcon, WorkspaceLeaf } from "obsidian";
 import { Root, createRoot } from "react-dom/client";
 import { GPT_VIEW_TYPE, APP_ICON } from "@/constants";
 import PluginContextProvider from "@/components/PluginContext";
@@ -41,15 +41,20 @@ export default class GptView extends ItemView {
 		const root = createRoot(this.containerEl.children[1]);
 		this.root = root;
 
-		root.render(
+		await root.render(
 			<PluginContextProvider
 				settings={this.settings}
 				pluginServices={this.pluginServices}
 			>
-				<h4 className="gpt-view-title">GPT Chat</h4>
+				<div className="gpt-view-title"></div>
 				<Messages />
 			</PluginContextProvider>
 		);
+
+		const titleBarElem = this.contentEl.getElementsByClassName(
+			"gpt-view-title"
+		)[0] as HTMLElement;
+		setIcon(titleBarElem, "bird");
 	}
 
 	async onClose(): Promise<void> {

--- a/styles.css
+++ b/styles.css
@@ -5,11 +5,15 @@
 	left: 0;
 	z-index: 1000; /* Ensures the header is above other content */
 	background: var(--background-primary);
-	opacity: 0.88;
+	color: var(--h4-color);
+	border-bottom: 1px solid var(--h4-color);
+	opacity: 0.9;
 	margin-block-start: 0;
-	padding: 0.33rem 1rem 0.5rem;
+	height: 2.5rem;
+	padding: 0.7rem 1rem 0;
 	width: 100%;
 	font-weight: 400;
+	--icon-size: var(--icon-m);
 }
 .gpt-messages {
 	padding: 1rem 0.5rem 5rem;


### PR DESCRIPTION
As a user, I want the chat bar to display an icon instead of the text "GPT Chat" to provide a more visually streamlined interface.

**Tasks:**

- [x] Investigate how to replace the "GPT Chat" text in the chat bar with an icon.
- [x] Implement the icon in place of the "GPT Chat" text in the chat bar.