### PR TITLE
"New Chat" link/button/hotkey (#72)

### DIFF
--- a/src/ApiService.ts
+++ b/src/ApiService.ts
@@ -20,7 +20,7 @@ export default class ApiService {
 			apiKey: this.settings.openaiApiKey,
 			dangerouslyAllowBrowser: true,
 		});
-		this.payloadMessages = new PayloadMessages();
+		this.payloadMessages = PayloadMessages.getInstance();
 	}
 
 	hasApiKey(): boolean {

--- a/src/Features.ts
+++ b/src/Features.ts
@@ -18,7 +18,7 @@ export default class Features {
 		this.app = app;
 		this.apiService = apiService;
 		this.settings = settings;
-		this.payloadMessages = new PayloadMessages();
+		this.payloadMessages = PayloadMessages.getInstance();
 		this.featuresRegistry = FeaturesRegistry(app);
 		this.executeFeature = this.executeFeature.bind(this);
 		this.pluginServices = apiService.pluginServices;

--- a/src/PayloadMessages.ts
+++ b/src/PayloadMessages.ts
@@ -2,9 +2,17 @@ import { PayloadMessagesType } from "@/interfaces";
 
 class PayloadMessages {
 	payloadMessages: PayloadMessagesType[];
+	public static instance: PayloadMessages;
 
 	constructor() {
 		this.payloadMessages = [];
+	}
+
+	static getInstance(): PayloadMessages {
+		if (!PayloadMessages.instance) {
+			PayloadMessages.instance = new PayloadMessages();
+		}
+		return PayloadMessages.instance;
 	}
 
 	getPayloadMessages(): PayloadMessagesType[] {

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -3,6 +3,8 @@ import { usePluginContext } from "@/components/PluginContext";
 import { Role } from "@/interfaces";
 import emitter from "@/customEmitter";
 import Message from "@/components/Message";
+import PayloadMessages from "@/PayloadMessages";
+import TitleBar from "@/components/TitleBar";
 
 export interface MessageType {
 	id: string;
@@ -22,6 +24,12 @@ const Messages: React.FC = () => {
 	const latestMessageRef = useRef<MessageType | null>(null);
 	const lastScrollPositionRef = useRef(0);
 	const SCROLL_THRESHOLD_CHARS = 400;
+	const payloadMessages = PayloadMessages.getInstance();
+
+	const clearMessages = () => {
+		setMessages([]);
+		payloadMessages.clearPayloadMessages();
+	};
 
 	// Add a new message
 	useEffect(() => {
@@ -176,6 +184,7 @@ const Messages: React.FC = () => {
 	return (
 		<>
 			<div id="oq-messages">
+				<TitleBar clearMessages={clearMessages} />
 				{messages.map((message, index) => (
 					<Message key={message.id} {...message} dataId={`message-${index}`} />
 				))}

--- a/src/components/TitleBar.tsx
+++ b/src/components/TitleBar.tsx
@@ -1,0 +1,13 @@
+interface TitleBarProps {
+	clearMessages: () => void;
+}
+
+const TitleBar: React.FC<TitleBarProps> = ({ clearMessages }) => {
+	return (
+		<div id="oq-view-title">
+			<div id="oq-btn-new-chat" onClick={clearMessages} />
+		</div>
+	);
+};
+
+export default TitleBar;

--- a/src/components/view.tsx
+++ b/src/components/view.tsx
@@ -52,18 +52,17 @@ export default class QuillView extends ItemView {
 				pluginServices={this.pluginServices}
 				apiService={this.apiService}
 			>
-				<div id="oq-view-title" />
 				<Messages />
 				<MessagePad executeFeature={this.features.executeFeature} />
 			</PluginContextProvider>
 		);
 
-		// Create view title bar with icon.
-		// setTimout ensures that the content element is rendered before
-		// the title bar element is created.
+		// Add the New Chat icon
 		setTimeout(() => {
-			const titleBar = document.getElementById("oq-view-title") as HTMLElement;
-			setIcon(titleBar, APP_PROPS.appIcon);
+			const newChatButton = document.getElementById(
+				"oq-btn-new-chat"
+			) as HTMLElement;
+			setIcon(newChatButton, APP_PROPS.appIcon);
 		}, 0);
 	}
 

--- a/styles.css
+++ b/styles.css
@@ -18,12 +18,13 @@
 [data-type="quill-chat-view"] .view-content {
 	display: grid;
 	grid-gap: 0;
-	grid-template-rows: var(--oq-view-title-height) 1fr var(
-			--oq-message-pad-height
-		);
+	grid-template-rows: 1fr var(--oq-message-pad-height);
 	padding: 0;
 }
 #oq-view-title {
+	position: absolute;
+	top: 0;
+	height: var(--oq-view-title-height);
 	background: var(--background-primary);
 	color: var(--oq-app-faint-color);
 	border-bottom: 2px solid var(--oq-app-faint-color);
@@ -33,7 +34,7 @@
 	--icon-size: var(--icon-m);
 	transition: color 0.2s ease, border-color 0.2s ease;
 }
-#oq-view-title::after {
+#oq-btn-new-chat:after {
 	position: relative;
 	bottom: 0.35rem;
 	margin-left: 0.5rem;
@@ -41,15 +42,16 @@
 	font-size: small;
 	color: var(--oq-app-faint-color);
 	transition: color 0.2s ease;
-	cursor: pointer;
+	/* cursor: pointer; */
 }
-#oq-view-title:hover::after {
-	color: var(--oq-view-title-height);
+#oq-btn-new-chat:hover::after {
+	color: var(--oq-app-bright-color);
 }
 #oq-messages {
 	display: grid;
 	grid-auto-rows: min-content;
 	gap: 0.5rem;
+	padding-top: var(--oq-view-title-height);
 	max-height: 100%;
 	overflow-y: scroll;
 	line-height: var(--line-height-normal);
@@ -190,7 +192,7 @@ button.oq-prompt-send:enabled:hover {
 	mask-image: linear-gradient(to top, transparent, black 2rem);
 	-webkit-mask-image: linear-gradient(to top, transparent, black 2rem);
 	cursor: pointer;
-	transition: opacity 0.25s ease;
+	transition: opacity 0.5s ease;
 }
 .oq-message-selectedtext-content:hover {
 	opacity: 0.7;
@@ -221,6 +223,7 @@ button.oq-prompt-send:enabled:hover {
 	max-height: none;
 	mask-image: none;
 	-webkit-mask-image: none;
+	transition: max-height 0.5s ease;
 	/* cursor: auto; */ /* <- Not sure about this. Has trade offs. */
 }
 /* End WDS technique */


### PR DESCRIPTION
As a user, I would like to start a new chat thread, simultaneously clearing any existing chat. Currently I have no way of doing that except by closing and reopening the plugin.

**Tasks**

- [x] New Chat icon and link on the title bar
- [x] Test