### PR TITLE
Settings: Add Default Model Menu

### DIFF
--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -111,14 +111,11 @@ const Messages: React.FC = () => {
 
 	// Control the message navigation
 	const goToMessage = (nav: "next" | "prev" | "first" | "last") => {
-		let atLastMsg = false;
 		setCurrentIndex((prevIndex) => {
 			let newIndex = prevIndex;
 			switch (nav) {
 				case "next":
-					atLastMsg = prevIndex === messages.length - 1;
-					newIndex = atLastMsg ? prevIndex : prevIndex + 1;
-					highlightMessage(newIndex);
+					newIndex = Math.min(messages.length - 1, prevIndex + 1);
 					break;
 				case "prev":
 					newIndex = Math.max(0, prevIndex - 1);
@@ -130,13 +127,9 @@ const Messages: React.FC = () => {
 					newIndex = messages.length - 1;
 					break;
 			}
-			if (atLastMsg) {
-				scrollToBottom();
-			} else {
-				scrollToMessage(newIndex);
-				clearHighlights("oq-message-highlight");
-				highlightMessage(newIndex);
-			}
+			scrollToMessage(newIndex);
+			clearHighlights("oq-message-highlight");
+			highlightMessage(newIndex);
 			return newIndex;
 		});
 	};

--- a/src/main.ts
+++ b/src/main.ts
@@ -178,7 +178,8 @@ export default class QuillPlugin extends Plugin implements IPluginServices {
 			const chatViewContainer = leaf.view.containerEl
 				.children[1] as HTMLElement;
 			chatViewContainer.tabIndex = 0;
-			// chatViewContainer.focus();
+			const chatViewInput = chatViewContainer?.querySelector("textarea");
+			chatViewInput?.focus();
 		} else {
 			this.notifyError("viewError");
 		}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,8 +15,32 @@ const openaiBaseUrl = "https://api.openai.com/v1";
 export const DEFAULT_SETTINGS: QuillPluginSettings = {
 	openaiApiKey: "",
 	openaiEnginesUrl: `${openaiBaseUrl}/engines`,
-	openaiModel: "gpt-3.5-turbo",
+	openaiModel: "gpt-3.5-turbo-0125",
 	openaiTemperature: 0.7,
+};
+
+interface OpenAIModels {
+	user: {
+		model: string;
+		display: string;
+	}[];
+}
+
+export const OPENAI_MODELS: OpenAIModels = {
+	user: [
+		{
+			model: "gpt-4o",
+			display: "GPT-4o",
+		},
+		{
+			model: "gpt-3.5-turbo-0125",
+			display: "GPT-3.5 Turbo (0125)",
+		},
+		{
+			model: "gpt-3.5-turbo-instruct",
+			display: "GPT-3.5 Turbo Instruct",
+		},
+	],
 };
 
 export class QuillSettingsTab extends PluginSettingTab {
@@ -32,10 +56,14 @@ export class QuillSettingsTab extends PluginSettingTab {
 
 		containerEl.empty();
 
+		this.containerEl.createEl("h3", {
+			text: "Obsidian Quill Settings",
+		});
+
 		// OpenAI API Key
 		new Setting(containerEl)
-			.setName("Settings")
-			.setDesc("OpenAI API Key")
+			.setName("OpenAI API Key")
+			.setDesc("Enter your OpenAI API key.")
 			.addText((text) =>
 				text
 					.setPlaceholder("Enter your key")
@@ -47,22 +75,21 @@ export class QuillSettingsTab extends PluginSettingTab {
 			);
 
 		// OpenAI Model
-		// User can set the default model, or if left blank, the plugin will
-		// use the model from DEFAULT_SETTINGS
-		new Setting(containerEl).setDesc("Default Model").addText((text) =>
-			text
-				.setPlaceholder("Select model")
-				.setValue(
-					this.plugin.settings.openaiModel.length
-						? this.plugin.settings.openaiModel
-						: DEFAULT_SETTINGS.openaiModel
-				)
-				.onChange(async (value) => {
-					this.plugin.settings.openaiModel = value.length
-						? value
-						: DEFAULT_SETTINGS.openaiModel;
+		new Setting(containerEl)
+			.setName("OpenAI Model")
+			.setDesc(
+				"Set the default model for Quill commands. (Some commands will " +
+					"use a different model tailored to their specific purpose.)"
+			)
+			.addDropdown((dropdown) => {
+				OPENAI_MODELS.user.forEach((model) =>
+					dropdown.addOption(model.model, model.display)
+				);
+				dropdown.setValue(this.plugin.settings.openaiModel);
+				dropdown.onChange(async (model) => {
+					this.plugin.settings.openaiModel = model;
 					await this.plugin.saveSettings();
-				})
-		);
+				});
+			});
 	}
 }


### PR DESCRIPTION
As a user, I want to select my preferred GPT model from a dropdown menu in the plugin's settings. This will allow me to set a default model that the plugin will use for generating responses, ensuring that the interactions are aligned with my specific needs or preferences.

  - [x] Design and implement a dropdown menu in the plugin's settings page for selecting the GPT model.
  - [x] Populate the dropdown menu with a list of available GPT models
  - [x] Update the plugin's settings storage to save the user's selected default model.
  - [x] Ensure that the selected default model is used in all GPT API calls made by the plugin.