### PR TITLE
Stop scrolling a streaming response before it goes under title bar [#99]

### DIFF
--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -13,22 +13,20 @@ const Messages: React.FC = () => {
 	const [messages, setMessages] = useState<MessageType[]>([]);
 	const [, setCurrentIndex] = useState(0);
 	const latestMessageRef = useRef<MessageType | null>(null);
-	const lastScrollPositionRef = useRef(0);
+	const prevContentLengthRef = useRef<number>(0);
+	const prevScrollTop = useRef<number>(0);
+	const stopScrolling = useRef<boolean>(false);
 	const payloadMessages = PayloadMessages.getInstance();
 
-	const newChat = async (event: React.MouseEvent<HTMLElement>) => {
-		let success = false;
-		if (!event.altKey) {
-			success = await saveMessages();
-		}
-		if (success || event.altKey) {
-			setMessages([]);
-			payloadMessages.clearAll();
-		}
+	const getContainerElem = (): HTMLElement | null => {
+		return document.getElementById("oq-messages");
+	};
+
+	const getMessageElem = (index: number): HTMLElement | null => {
+		return document.querySelector(`[data-idx="message-${index}"]`);
 	};
 
 	const saveMessages = async () => {
-		// const messages = payloadMessages.getAll(false);
 		if (messages.length) {
 			const filename = await vaultUtils.saveConversationToFile(
 				messages,
@@ -42,8 +40,46 @@ const Messages: React.FC = () => {
 		}
 	};
 
-	// Add a new message
+	const newConversation = async (event: React.MouseEvent<HTMLElement>) => {
+		let success = false;
+		if (!event.altKey) {
+			success = await saveMessages();
+		}
+		if (success || event.altKey) {
+			setMessages([]);
+			payloadMessages.clearAll();
+		}
+	};
+
+	// SCROLL HANDLER
 	useEffect(() => {
+		if (stopScrolling.current) return;
+
+		const container = getContainerElem();
+		if (!container) return;
+
+		const handleScroll = () => {
+			// Stop scrolling if the user scrolls up
+			const isScrollingDown = container.scrollTop < prevScrollTop.current;
+			if (isScrollingDown) {
+				stopScrolling.current = true;
+				return;
+			}
+			prevScrollTop.current = container.scrollTop;
+		};
+		container.addEventListener("scroll", handleScroll);
+
+		return () => {
+			container.removeEventListener("scroll", handleScroll);
+		};
+	}, []);
+
+	// NEW MESSAGE
+	// Add a new message to the chat when a new message is received
+	useEffect(() => {
+		const container = getContainerElem();
+		if (!container) return;
+
 		const handleNewMessage = (role: Role, selectedText: string) => {
 			const newMessage: MessageType = {
 				id: generateUniqueId(),
@@ -53,17 +89,21 @@ const Messages: React.FC = () => {
 				selectedText: selectedText,
 			};
 			latestMessageRef.current = newMessage;
+			prevContentLengthRef.current = 0;
+			stopScrolling.current = false;
 			setMessages((prevMessages) => {
-				const updatedMessages = [...prevMessages, newMessage];
-				return updatedMessages;
+				return [...prevMessages, newMessage];
 			});
+			prevScrollTop.current = container.scrollTop;
+			scrollToMessage(messages.length - 1);
 		};
 		emitter.on("newMessage", handleNewMessage);
 		return () => {
 			emitter.off("newMessage", handleNewMessage);
 		};
-	}, []);
+	}, [messages]);
 
+	// UPDATE MESSAGE
 	// Update the most recent message with streaming content from the API.
 	useEffect(() => {
 		const handleUpdateMessage = (response: string) => {
@@ -77,21 +117,14 @@ const Messages: React.FC = () => {
 					return updatedMessages;
 				});
 
-				const currentLength = latestMessageRef.current.content.length;
+				// Scroll after a sufficient number of chars have been added
+				const contentLength = latestMessageRef.current.content.length;
 				if (
-					currentLength >=
-					lastScrollPositionRef.current + SCROLL_THRESHOLD_CHARS
+					contentLength >=
+					prevContentLengthRef.current + SCROLL_THRESHOLD_CHARS
 				) {
-					console.log(
-						'document.getElementById("oq-messages")?.scrollTop',
-						document.getElementById("oq-messages")?.scrollTop
-					);
-					console.log(
-						"lastScrollPositionRef.current",
-						lastScrollPositionRef.current
-					);
-					scrollToBottom();
-					lastScrollPositionRef.current = currentLength;
+					scrollToMessage(messages.length - 1);
+					prevContentLengthRef.current = contentLength;
 				}
 			}
 		};
@@ -99,34 +132,24 @@ const Messages: React.FC = () => {
 		return () => {
 			emitter.off("updateMessage", handleUpdateMessage);
 		};
-	}, []);
+	}, [messages]);
 
+	// STREAM END
 	// Clear the message highlight when the stream ends
 	useEffect(() => {
 		const handleStreamEnd = () => {
-			// setTimeout is necessary when the response is minimal, e.g. "1 2 3".
-			// Otherwise the highlight isn't cleared.
+			// setTimeout is necessary when the response is minimal,
+			// e.g. "1 2 3". Otherwise the highlight isn't cleared.
 			setTimeout(() => {
 				clearHighlights("oq-message-streaming");
-				lastScrollPositionRef.current = 0;
-				scrollToBottom();
+				scrollToMessage(messages.length - 1);
 			}, 0);
 		};
 		emitter.on("streamEnd", handleStreamEnd);
 		return () => {
 			emitter.off("streamEnd", handleStreamEnd);
 		};
-	}, []);
-
-	// Scroll to bottom when the assistant sends a message
-	useEffect(() => {
-		if (messages.length > 0 && latestMessageRef.current?.role === "assistant") {
-			const timer = setTimeout(() => {
-				scrollToBottom();
-			}, 0);
-			return () => clearTimeout(timer);
-		}
-	}, [messages.length]);
+	}, [messages]);
 
 	// Control the message navigation
 	const goToMessage = (nav: "next" | "prev" | "first" | "last") => {
@@ -146,7 +169,7 @@ const Messages: React.FC = () => {
 					newIndex = messages.length - 1;
 					break;
 			}
-			scrollToMessage(newIndex);
+			scrollToMessage(newIndex, true);
 			clearHighlights("oq-message-highlight");
 			highlightMessage(newIndex);
 			return newIndex;
@@ -192,89 +215,84 @@ const Messages: React.FC = () => {
 		};
 	}, [apiService, pluginServices, messages.length]);
 
+	// Generate a unique ID for each message
+	const generateUniqueId = () => {
+		return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+	};
+
+	const getMessagePos = (container: HTMLElement, message: HTMLElement) => {
+		let messagePos = 0;
+		const containerRect = container.getBoundingClientRect();
+		const messageRect = message.getBoundingClientRect();
+
+		messagePos = messageRect.top - containerRect.top + container.scrollTop;
+		return messagePos;
+	};
+
+	// Utility functions for highlighting messages
+	const highlightMessage = (index: number) => {
+		const messageElement = getMessageElem(index);
+		messageElement?.classList.add("oq-message-highlight");
+		setTimeout(() => {
+			clearHighlights("oq-message-highlight");
+		}, 100);
+	};
+
+	const clearHighlights = (msgClassName: string) => {
+		const classSelector = `.${msgClassName}`;
+		const highlightedMessages = document.querySelectorAll(classSelector);
+		highlightedMessages.forEach((message) => {
+			message.classList.remove(msgClassName);
+		});
+	};
+
+	// Scroll to a specific message
+	const scrollToMessage = (index: number, isMsgNav?: boolean): void => {
+		if (!isMsgNav && stopScrolling.current) return;
+		const container = getContainerElem();
+		const message = getMessageElem(index);
+		if (!container || !message) return;
+
+		const titleBarHeight =
+			document.getElementById("oq-view-title")?.offsetHeight || 0;
+		const messagePadHeight =
+			document.getElementById("oq-message-pad")?.offsetHeight || 0;
+		const viewPortHeight =
+			container.offsetHeight - titleBarHeight - messagePadHeight;
+
+		// If the message is taller than the viewable area,
+		// scroll the message to the top of the view port
+		if (message.offsetHeight >= viewPortHeight) {
+			const messagePos = getMessagePos(container, message);
+			if (!messagePos) return;
+
+			// 12 corresponds to #oq-messages padding-top
+			const scrollToPosition = messagePos - titleBarHeight - 12;
+			container.scrollTo({
+				top: scrollToPosition,
+				behavior: "smooth",
+			});
+		}
+		// Otherwise, scroll the message into view, centered
+		else {
+			message.scrollIntoView({
+				block: "center",
+				behavior: "smooth",
+			});
+		}
+	};
+
 	// Render the messages
 	return (
 		<>
 			<div id="oq-messages">
-				<TitleBar newChat={newChat} />
+				<TitleBar newChat={newConversation} />
 				{messages.map((message, index) => (
 					<Message key={message.id} {...message} dataIdx={`message-${index}`} />
 				))}
-				<div id="oq-messages-shim" />
 			</div>
 		</>
 	);
-};
-
-// Generate a unique ID for each message
-const generateUniqueId = () => {
-	return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
-};
-
-// Scroll to a specific message
-export const scrollToMessage = (index: number) => {
-	const container = document.getElementById("oq-messages");
-	const message = document.querySelector(
-		`[data-idx="message-${index}"]`
-	) as HTMLElement;
-	if (!container || !message) return;
-	const titleBar = document.getElementById("oq-view-title");
-	const titleBarHeight = titleBar?.offsetHeight || 40;
-
-	const messagePos = getMessagePos(container, message);
-
-	if (!messagePos) return;
-
-	// 12 corresponds to oq-messages padding-top
-	const scrollToPosition = messagePos - titleBarHeight - 12;
-
-	// If the message is taller than the chat container,
-	// scroll the message to the top of the container
-	if (message.offsetHeight > container.offsetHeight) {
-		container.scrollTo({
-			top: scrollToPosition,
-			behavior: "smooth",
-		});
-	} else {
-		// Otherwise, scroll the message into view, centered
-		message.scrollIntoView({
-			block: "center",
-			behavior: "smooth",
-		});
-	}
-};
-
-const getMessagePos = (container: HTMLElement, message: HTMLElement) => {
-	let messagePos = 0;
-	const containerRect = container.getBoundingClientRect();
-	const messageRect = message.getBoundingClientRect();
-
-	messagePos = messageRect.top - containerRect.top + container.scrollTop;
-	return messagePos;
-};
-
-const scrollToBottom = () => {
-	const bottom = document.getElementById("oq-messages-shim");
-	bottom?.scrollIntoView({ behavior: "smooth" });
-};
-
-// Utility functions for highlighting messages
-export const highlightMessage = (index: number) => {
-	const messageElement = document.querySelector(
-		`[data-idx="message-${index}"]`
-	);
-	messageElement?.classList.add("oq-message-highlight");
-	setTimeout(() => {
-		clearHighlights("oq-message-highlight");
-	}, 100);
-};
-
-export const clearHighlights = (msgClassName: string) => {
-	const classSelector = `.${msgClassName}`;
-	const highlightedMessages = document.querySelectorAll(classSelector);
-	highlightedMessages.forEach((message) => {
-		message.classList.remove(msgClassName);
-	});
 };
 
 export default Messages;

--- a/styles.css
+++ b/styles.css
@@ -78,6 +78,7 @@
 	grid-auto-rows: min-content;
 	gap: 0.5rem;
 	padding-top: calc(var(--oq-view-title-height) + 12px);
+	padding-bottom: 1.25rem;
 	max-height: 100%;
 	overflow-y: scroll;
 	line-height: var(--line-height-normal);
@@ -85,9 +86,6 @@
 	mask-image: linear-gradient(to top, transparent 0, white 2rem);
 	-webkit-mask-image: linear-gradient(to top, transparent 0, white 2rem);
 	scroll-behavior: smooth;
-}
-#oq-messages-shim {
-	height: 4rem;
 }
 .oq-message {
 	display: grid; /* Need this here to all pre scroll */


### PR DESCRIPTION
As a user, during a streaming response, I want auto-scroll to deactivate if I scroll manually in the conversation view. This allows me to read at my own pace without having to scroll back up to earlier in the message.

Stop auto-scrolling if the user manually scrolls [#104]

As a user, I want to stop auto-scrolling during a streaming response so I can read where I'm at without it moving off the screen.