### PR TITLE
Remember "Open file after saving" setting [#108]

### DIFF
--- a/src/VaultUtils.ts
+++ b/src/VaultUtils.ts
@@ -88,12 +88,11 @@ class VaultUtils {
 	async saveConversationToFile(
 		messages: MessageType[],
 		vault: Vault,
-		settings: QuillPluginSettings,
-		pluginServices: IPluginServices
+		settings: QuillPluginSettings
 	): Promise<string | null> {
 		const fileText = this.formatConversationForFile(messages);
 		if (!fileText.length) {
-			pluginServices.notifyError("saveError");
+			this.pluginServices.notifyError("saveError");
 			return null;
 		}
 		try {
@@ -133,6 +132,9 @@ class VaultUtils {
 				message,
 				this.getAllFolders(vault).sort(),
 				async (fileName, folderPath, openFile) => {
+					if (!fileName.length) {
+						fileName = this.createFilenameAsDatetime("md");
+					}
 					const filename = this.sanitizeFilename(
 						fileName.endsWith(".md") ? fileName : fileName + ".md"
 					);
@@ -141,6 +143,8 @@ class VaultUtils {
 						await vault.create(filepath, fileText);
 						new Notice(`${filename}\n  saved to\n${folderPath}`);
 						modal.close();
+						this.settings.openSavedFile = openFile;
+						await this.pluginServices.saveSettings();
 						if (openFile) {
 							this.openFile(vault, filepath);
 						}

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -31,8 +31,7 @@ const Messages: React.FC = () => {
 			const filename = await vaultUtils.saveConversationToFile(
 				messages,
 				vault,
-				settings,
-				pluginServices
+				settings
 			);
 			return !!filename;
 		} else {

--- a/src/components/ModalSaveMessageAs.tsx
+++ b/src/components/ModalSaveMessageAs.tsx
@@ -80,6 +80,7 @@ class ModalSaveMessageAs extends Modal {
 				type: "checkbox",
 			},
 		});
+		openFile.checked = this.settings.openSavedFile;
 		footer.createEl("label", {
 			text: "Open file after saving",
 			attr: {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,6 +5,7 @@ export interface IPluginServices {
 	toggleView(): Promise<void>;
 	getViewElem(): HTMLElement | null;
 	notifyError(errorCode: string, consoleMsg?: string): void;
+	saveSettings(): Promise<void>;
 }
 
 export interface GptEngines {

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ export default class QuillPlugin extends Plugin implements IPluginServices {
 			toggleView: this.toggleView.bind(this),
 			getViewElem: this.getViewElem.bind(this),
 			notifyError: this.notifyError.bind(this),
+			saveSettings: this.saveSettings.bind(this),
 		};
 		this.vault = this.app.vault;
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,6 +9,7 @@ export interface QuillPluginSettings {
 	openaiTemperature: number;
 	conversationsFolder: string;
 	messagesFolder: string;
+	openSavedFile: boolean;
 }
 
 const openaiBaseUrl = "https://api.openai.com/v1";
@@ -21,6 +22,7 @@ export const DEFAULT_SETTINGS: QuillPluginSettings = {
 	openaiTemperature: 0.7,
 	conversationsFolder: "Quill",
 	messagesFolder: "Quill",
+	openSavedFile: false,
 };
 
 interface OpenAIModels {


### PR DESCRIPTION
As a user, I would like the Save Message As feature to remember what I selected for "Open file after saving"

Also added missing date/time stamp for saving conversations if no filename was provided.